### PR TITLE
对waifu群聊的优化

### DIFF
--- a/cells/generator.py
+++ b/cells/generator.py
@@ -223,7 +223,7 @@ class Generator:
         if "<think>" in result:
             self.ap.logger.warning("未能完全删除think标签")
             self.ap.logger.warning(result)
-            result = "喵~"
+            result = ""
         return result
 
     def _parse_json_list(self, response: str, generate_tags: bool = False) -> list:

--- a/cells/generator.py
+++ b/cells/generator.py
@@ -219,7 +219,11 @@ class Generator:
 
         if iteration >= max_iterations:
             self.ap.logger.warning(f"达到最大迭代次数 {max_iterations}，可能存在异常标签")
-
+        # 针对启航API的返回信息不全的处理
+        if "<think>" in result:
+            self.ap.logger.warning("未能完全删除think标签")
+            self.ap.logger.warning(result)
+            result = "喵~"
         return result
 
     def _parse_json_list(self, response: str, generate_tags: bool = False) -> list:

--- a/main.py
+++ b/main.py
@@ -91,7 +91,7 @@ class WaifuRunner(runner.RequestRunner):
 
 @register(name="Waifu", description="Cuter than real waifu!", version="1.9.6", author="ElvisChenML")
 class Waifu(BasePlugin):
-
+    bot_account_id: int
     def __init__(self, host: APIHost):
         self.ap = host.ap
         self._ensure_required_files_exist()
@@ -115,6 +115,7 @@ class Waifu(BasePlugin):
         :param ctx: 包含事件上下文信息的 EventContext 对象
         :return: True if allowed to continue, False otherwise
         """      
+        self.bot_account_id = ctx.event.query.adapter.bot_account_id
         text_message = str(ctx.event.query.message_chain)
         launcher_id = ctx.event.launcher_id
         sender_id = ctx.event.sender_id
@@ -237,7 +238,9 @@ class Waifu(BasePlugin):
                     await runner_mgr.using_runner.initialize()
                     break
             else:
-                raise Exception("Runner 'waifu-mode' not found in preregistered_runners.")
+                raise Exception(
+                    "Runner 'waifu-mode' not found in preregistered_runners."
+                )
 
     async def _handle_command(self, ctx: EventContext) -> typing.Tuple[bool, bool]:
         need_assistant_reply = False
@@ -452,7 +455,7 @@ class Waifu(BasePlugin):
         config.unreplied_count = 0
         user_prompt = config.memory.get_normalize_short_term_memory()  # 默认为当前short_term_memory_size条聊天记录
         if config.thinking_mode_flag:
-            user_prompt, analysis = await config.thoughts.generate_group_prompt(config.memory, config.cards, unreplied_count)
+            user_prompt, analysis = await config.thoughts.generate_group_prompt(config.memory, config.cards, unreplied_count,self.bot_account_id)
             if config.display_thinking and config.conversation_analysis_flag:
                 await self._reply(ctx, f"【分析】：{analysis}")
         self._generator.set_speakers([config.memory.assistant_name])

--- a/main.py
+++ b/main.py
@@ -141,7 +141,8 @@ class Waifu(BasePlugin):
         if launcher_id not in self.waifu_cache:
             await self._load_config(launcher_id, ctx.event.launcher_type)
         waifu_data = self.waifu_cache.get(launcher_id, None)
-
+        if waifu_data:
+            waifu_data.memory.bot_account_id = self.bot_account_id
         # 继承LangBot的群消息响应规则时忽略 GroupMessageReceived 信号
         if event_type == "GMR" and waifu_data.langbot_group_rule == True:
             return False
@@ -448,7 +449,7 @@ class Waifu(BasePlugin):
             related_memories = await config.memory.load_memory(unreplied_conversations)
             if related_memories:
                 config.cards.set_memory(related_memories)
-
+        # 如果是群聊则不修改为自定义角色名
         system_prompt = config.memory.to_custom_names(config.cards.generate_system_prompt())
         # 备份然后重置避免回复过程中接收到新讯息导致计数错误
         unreplied_count = config.unreplied_count

--- a/main.py
+++ b/main.py
@@ -91,7 +91,6 @@ class WaifuRunner(runner.RequestRunner):
 
 @register(name="Waifu", description="Cuter than real waifu!", version="1.9.6", author="ElvisChenML")
 class Waifu(BasePlugin):
-    bot_account_id: int
     def __init__(self, host: APIHost):
         self.ap = host.ap
         self._ensure_required_files_exist()
@@ -115,7 +114,7 @@ class Waifu(BasePlugin):
         :param ctx: 包含事件上下文信息的 EventContext 对象
         :return: True if allowed to continue, False otherwise
         """      
-        self.bot_account_id = ctx.event.query.adapter.bot_account_id
+        bot_account_id = ctx.event.query.adapter.bot_account_id
         text_message = str(ctx.event.query.message_chain)
         launcher_id = ctx.event.launcher_id
         sender_id = ctx.event.sender_id
@@ -142,7 +141,7 @@ class Waifu(BasePlugin):
             await self._load_config(launcher_id, ctx.event.launcher_type)
         waifu_data = self.waifu_cache.get(launcher_id, None)
         if waifu_data:
-            waifu_data.memory.bot_account_id = self.bot_account_id
+            waifu_data.memory.bot_account_id = bot_account_id
         # 继承LangBot的群消息响应规则时忽略 GroupMessageReceived 信号
         if event_type == "GMR" and waifu_data.langbot_group_rule == True:
             return False
@@ -456,7 +455,7 @@ class Waifu(BasePlugin):
         config.unreplied_count = 0
         user_prompt = config.memory.get_normalize_short_term_memory()  # 默认为当前short_term_memory_size条聊天记录
         if config.thinking_mode_flag:
-            user_prompt, analysis = await config.thoughts.generate_group_prompt(config.memory, config.cards, unreplied_count,self.bot_account_id)
+            user_prompt, analysis = await config.thoughts.generate_group_prompt(config.memory, config.cards, unreplied_count)
             if config.display_thinking and config.conversation_analysis_flag:
                 await self._reply(ctx, f"【分析】：{analysis}")
         self._generator.set_speakers([config.memory.assistant_name])

--- a/organs/memories.py
+++ b/organs/memories.py
@@ -16,7 +16,7 @@ from plugins.Waifu.cells.config import ConfigManager
 class Memory:
 
     ap: app.Application
-
+    bot_account_id: int
     def __init__(self, ap: app.Application, launcher_id: str, launcher_type: str):
         self.ap = ap
         self.short_term_memory: typing.List[llm_entities.Message] = []
@@ -121,7 +121,7 @@ class Memory:
             user_prompt_summary = f"""总结以下对话中的最重要细节和事件: "{conversations_str}"。将总结限制在200字以内。总结应使用中文书写，并以过去式书写。你的回答应仅包含总结。"""
         else:
             conversations_str = self.get_conversations_str_for_group(conversations)
-        user_prompt_summary = f"""总结以下对话中的最重要细节和事件: "{conversations_str}"。将总结限制在200字以内。总结应使用中文书写，并以过去式书写。你的回答应仅包含总结。"""
+            user_prompt_summary = f"""总结以下对话中的最重要细节和事件: "{conversations_str}"。将总结限制在200字以内。总结应使用中文书写，其中@{self.bot_account_id}为对你说的话，或对你的动作，并以过去式书写。你的回答应仅包含总结。"""
 
         return await self._generator.return_string(user_prompt_summary)
 

--- a/organs/thoughts.py
+++ b/organs/thoughts.py
@@ -119,7 +119,7 @@ class Thoughts:
         analysis_result = await self._generator.return_string(user_prompt)
         return analysis_result
 
-    async def generate_group_prompt(self, memory: Memory, card: Cards, unreplied_count: int) -> typing.Tuple[str, str]:
+    async def generate_group_prompt(self, memory: Memory, card: Cards, unreplied_count: int,bot_account_id) -> typing.Tuple[str, str]:
         conversations = memory.short_term_memory
         count, unreplied_conversations = memory.get_unreplied_msg(unreplied_count)
         replied_conversations = conversations[:-count]
@@ -140,8 +140,7 @@ class Thoughts:
         else:
             user_prompt += f"这是未回复的群聊消息记录“{unreplied_conversations_str}”。消息格式为群友昵称说：“”。你要作为{memory.assistant_name}对未回复的群聊消息记录做出符合{memory.assistant_name}角色设定的回复。确保回复充分体现{memory.assistant_name}的性格特征和情感反应。"
 
-        user_prompt += f"不称呼群友昵称，使用你或你们代指群友。只提供{memory.assistant_name}的回复内容，不需要消息记录格式。"
-
+        user_prompt += f"其中@{bot_account_id} 表示对{memory.assistant_name}说的话,或是对{memory.assistant_name}的行动,{memory.assistant_name}应优先对最后一个动作做出反应,再考虑之前的聊天内容,只提供{memory.assistant_name}的回复内容，不需要消息记录格式。"
         return user_prompt, analysis
 
     async def analyze_picture(self, content_list: list[llm_entities.ContentElement]) -> str:

--- a/organs/thoughts.py
+++ b/organs/thoughts.py
@@ -119,7 +119,7 @@ class Thoughts:
         analysis_result = await self._generator.return_string(user_prompt)
         return analysis_result
 
-    async def generate_group_prompt(self, memory: Memory, card: Cards, unreplied_count: int,bot_account_id) -> typing.Tuple[str, str]:
+    async def generate_group_prompt(self, memory: Memory, card: Cards, unreplied_count: int) -> typing.Tuple[str, str]:
         conversations = memory.short_term_memory
         count, unreplied_conversations = memory.get_unreplied_msg(unreplied_count)
         replied_conversations = conversations[:-count]
@@ -140,7 +140,7 @@ class Thoughts:
         else:
             user_prompt += f"这是未回复的群聊消息记录“{unreplied_conversations_str}”。消息格式为群友昵称说：“”。你要作为{memory.assistant_name}对未回复的群聊消息记录做出符合{memory.assistant_name}角色设定的回复。确保回复充分体现{memory.assistant_name}的性格特征和情感反应。"
 
-        user_prompt += f"其中@{bot_account_id} 表示对{memory.assistant_name}说的话,或是对{memory.assistant_name}的行动,{memory.assistant_name}应优先对最后一个动作做出反应,再考虑之前的聊天内容,只提供{memory.assistant_name}的回复内容，不需要消息记录格式。"
+        user_prompt += f"其中@{memory.bot_account_id} 表示对{memory.assistant_name}说的话,或是对{memory.assistant_name}的行动,{memory.assistant_name}应优先对最后一个动作做出反应,再考虑之前的聊天内容,只提供{memory.assistant_name}的回复内容，不需要消息记录格式。"
         return user_prompt, analysis
 
     async def analyze_picture(self, content_list: list[llm_entities.ContentElement]) -> str:


### PR DESCRIPTION
1.针对启航API出现过的仅有think缺少实际内容的问题进行优化
2.优化群聊提示词，防止答非所问
3.优化群聊长期记忆存储