### PR TITLE
移除 _delayed_person_reply 末尾的追赶调用，避免上下文不完整导致回复重复

### DIFF
--- a/main.py
+++ b/main.py
@@ -553,7 +553,7 @@ class WaifuPlugin(BasePlugin):
             config.continued_count = 0
 
             config.response_timers_flag = False
-            await self._person_reply(ctx)  # 检查是否回复期间又满足响应条件
+          #  await self._person_reply(ctx)  # 检查是否回复期间又满足响应条件 
 
         except Exception as e:
             self.ap.logger.error(f"Error occurred during person reply: {e}")


### PR DESCRIPTION
这个pr移除了 `_delayed_person_reply` 方法末尾的 `await self._person_reply(ctx)` 调用。


原代码中，`_delayed_person_reply` 完成回复后会重新调用 `_person_reply`。当用户快速连续发送消息时，这个机制可能导致这个追赶的问题，比如说：

前一个回复任务（任务A）刚执行完（清空了 `unreplied_count` 并重置了 `response_timers_flag`），如果此时如果用户紧接着发送了一条新的短消息（如“嗯”），“追赶机制”对 `_person_reply` 的调用会因为这条新消息而满足条件，从而创建一个新的回复任务（任务B）。

关键在于，**任务B获取到的对话上下文可能主要只包含了这条最新的短消息，而缺乏足够的先前对话历史**。那么大概率这导致LLM在上下文不完整的情况下生成回复，生成的内容**非常与之前的对话相似**。

**修改方案：**

我认为可以删除 `_delayed_person_reply` 方法末尾的 `await self._person_reply(ctx)`，来解决这个基本问题。

**预期效果：**

移除此调用后，基本上确保了回复流程总是由**累积的、完整的用户未回复消息触发**，避免了因处理不完整的即时短消息，而导致的上下文缺失和回复内容重复问题。

在我本地和服务器测试中，此修改解决了在快速连续发送消息时，机器人出现上下文混乱并重复回复先前对话内容的现象。

*ps：另外我还注意到到 `_reply` 中的 `_emit_responded_event` 在某些场景（如分段回复）也可能导致机器人将自身回复误认为用户输入，但我不确定是不是问题，我也注释掉了但是没有在这个分支上修改。*
