### PR TITLE
重写模型初始化方法，增加主动对话功能，修复长期记忆无法读取generator问题

### DIFF
--- a/main.py
+++ b/main.py
@@ -4,16 +4,11 @@ import json
 import traceback
 import typing
 import os
-from turtledemo.penrose import start
-
 import yaml
 import random
 import re
 import copy
 import shutil
-
-from google.api_core.retry import retry_target
-
 from pkg.platform.sources.aiocqhttp import AiocqhttpAdapter
 from pkg.provider import runner
 from pkg.core import app

--- a/main.py
+++ b/main.py
@@ -120,7 +120,6 @@ class WaifuPlugin(BasePlugin):
 
     async def initialize(self):  #重写初始化
         await super().initialize()  # 调用父类的 initialize (如果它有实际逻辑)
-        self.ap.logger.info("WaifuPlugin: Starting async initialization (initialize method)...")
 
         # --- 1. 初始化 Generator 的模型配置 ---
         if hasattr(self, '_generator') and hasattr(self._generator, '_initialize_model_config'):
@@ -130,52 +129,26 @@ class WaifuPlugin(BasePlugin):
                 if self._generator.selected_model_info:
                     self.ap.logger.info(
                         f"WaifuPlugin: Generator model selected: {self._generator.selected_model_info.model_entity.name}")
-                else:
-                    # 这个错误在 _set_selected_model 内部已经打印过了，这里可以不重复打印，或者只打一个简短的
-                    self.ap.logger.warning(
-                        "WaifuPlugin: Generator did not select a model after _initialize_model_config.")
             except Exception as e:
                 self.ap.logger.error(f"WaifuPlugin: Error during Generator model initialization: {e}")
                 self.ap.logger.error(traceback.format_exc())
         else:
             self.ap.logger.error("WaifuPlugin: _generator or _generator._initialize_model_config not found!")
 
-     ##结束1
 
 
     async def _get_target_adapter_for_test(self):
-        # print("WaifuPlugin Test: _get_target_adapter_for_test() called.") # 可以去掉更多
-        if not hasattr(self.ap, 'platform_mgr') or not self.ap.platform_mgr:
-            print("WaifuPlugin Test ERROR: self.ap.platform_mgr is not available.")
-            return None
+
         platform_manager = self.ap.platform_mgr
-        if not self.test_target_bot_uuid:
-            print("WaifuPlugin Test ERROR: test_target_bot_uuid is not set.")
-            return None
         runtime_bot = await platform_manager.get_bot_by_uuid(self.test_target_bot_uuid)
-        if not runtime_bot:
-            print(f"WaifuPlugin Test ERROR: Bot with UUID '{self.test_target_bot_uuid}' not found.")
-            return None
-        if not runtime_bot.enable:
-            print(
-                f"WaifuPlugin Test WARNING: Bot (UUID: {self.test_target_bot_uuid}) is not enabled, but attempting send for test.")
-        if not hasattr(runtime_bot, 'adapter'):
-            print(f"WaifuPlugin Test ERROR: RuntimeBot (UUID: {self.test_target_bot_uuid}) has no 'adapter' attribute.")
-            return None
         return runtime_bot.adapter
 
 
-
     async def _test_proactive_send(self):
-        print("WaifuPlugin Test: _test_proactive_send() task started.")
         try:
             adapter_instance = await self._get_target_adapter_for_test()
             if adapter_instance:
-
-
                 message_to_send_str = "洛希主动测试！(直接字符串版)" # 1. 定义要发送的文本字符串
-
-
 
                 await adapter_instance.send_message(
                     target_type="person",  # 直接将 "person" 字符串传入
@@ -183,10 +156,9 @@ class WaifuPlugin(BasePlugin):
                     message=platform_message.MessageChain([message_to_send_str])
                 )
 
-
-                print("WaifuPlugin Test: Proactive message send attempt FINISHED.")
             else:
                 print("WaifuPlugin Test ERROR: Could not get adapter instance for proactive send.")
+
         except Exception as e:
             print(f"WaifuPlugin Test ERROR during proactive send: {e}")
             traceback.print_exc()  # 保留这个
@@ -195,8 +167,6 @@ class WaifuPlugin(BasePlugin):
     ##初始化结束
 
         ##结束
-
-
 
 
     async def destroy(self):

--- a/templates/waifu.yaml
+++ b/templates/waifu.yaml
@@ -1,8 +1,8 @@
 # 通用设置
 character: "default" # off：不使用角色预设；请填Waifu/cards中的 “角色卡名称.yaml” 的 角色卡名称，使用默认值“default”时会使用模板config/default_*.yaml创建cards/default_*.yaml。
-summarization_mode: false # 是否开启长期记忆，不开启则超出short_term_memory_size直接截断。
+summarization_mode: true # 是否开启长期记忆，不开启则超出short_term_memory_size直接截断。
 story_mode: false # 是否开启剧情模式（旁白、状态栏），仅私聊模式生效。
-thinking_mode: true # 是否开启思维链。开启后模型将具备：更高的拟人化程度、区分不同群用户发言。注意：思维链会在一定程度上影响模型回复。
+thinking_mode: false # 是否开启思维链。开启后模型将具备：更高的拟人化程度、区分不同群用户发言。注意：思维链会在一定程度上影响模型回复。
 personate_mode: false # 是否启用拟人化：打字时间、分段回复。
 jail_break_mode: "off" # off/before/after/end/all；是否启用破甲，off：关闭破甲，before：系统提示前加入破甲提示，after：系统提示后加入破甲提示，end：上下文末尾加入破甲提示；all：全部启用；破甲内容请修改：jail_break_before.txt、jail_break_after.txt、jail_break_end.txt。
 langbot_group_rule: false # 是否继承LangBot的群消息响应规则；若启用继承LangBot的群消息响应规则，模型会忽略不在响应规则内的群聊记录；默认规则为接收处理全部群聊记录。
@@ -38,7 +38,7 @@ max_narrat_words: 30 # 最大旁白字数，此配置不是硬性限制，该配
 narrat_max_conversations: 8 # 用于生成旁白的最大对话数量。
 value_game_max_conversations: 5 # 判定数值变化时输入的最大对话数量。
 intervals: [] # 列表，自动触发旁白推进剧情的时间间隔，单位秒，例如：[300,600,1800,3600]：第一次5分钟、第二次10分钟、第三次30分钟、第四次一个小时，然后停止计时器。
-person_response_delay: 0 # 私聊消息合并等待时间（秒）。
+person_response_delay: 5 # 私聊消息合并等待时间（秒）。
 continued_rate: 0 # 自动触发回复后继续发言的机率。
 continued_max_count: 2 # 私聊最大延续发言次数。
 

--- a/templates/waifu.yaml
+++ b/templates/waifu.yaml
@@ -41,3 +41,12 @@ intervals: [] # 列表，自动触发旁白推进剧情的时间间隔，单位�
 person_response_delay: 0 # 私聊消息合并等待时间（秒）。
 continued_rate: 0 # 自动触发回复后继续发言的机率。
 continued_max_count: 2 # 私聊最大延续发言次数。
+
+#主动发言模式
+proactive_greeting_enabled: true # 是否开启主动发言
+proactive_greeting_probability: 50 # 0-100 触发主动发言几率
+proactive_min_inactive_hours: 3  #不活跃的最小小时数
+
+
+proactive_do_not_disturb_start: "23:00" # 晚上11点
+proactive_do_not_disturb_end: "08:00"   # 早上8点

--- a/templates/waifu.yaml
+++ b/templates/waifu.yaml
@@ -43,10 +43,11 @@ continued_rate: 0 # 自动触发回复后继续发言的机率。
 continued_max_count: 2 # 私聊最大延续发言次数。
 
 #主动发言模式
-proactive_greeting_enabled: true # 是否开启主动发言
+target_user_id : " "  #填入你想要bot主动发送的目标的qq号，如"13131313"（不是bot的qq！）
+proactive_greeting_enabled: True # 是否开启主动发言  ， 此模式依赖于长期记忆 ， 必须开启summarization_mode长期记忆模式
 proactive_greeting_probability: 50 # 0-100 触发主动发言几率
-proactive_min_inactive_hours: 3  #不活跃的最小小时数
+proactive_min_inactive_hours: 2.0 #不活跃的最小小时数 （最低0.5,要修改则去main.py里修改loop_time 的值）
 
+proactive_do_not_disturb_start: "23:00" # 勿扰时间开始  格式 "xx:xx "  二十四小时制
+proactive_do_not_disturb_end: "08:00" # 勿扰时间结束  格式 "xx:xx "
 
-proactive_do_not_disturb_start: "23:00" # 晚上11点
-proactive_do_not_disturb_end: "08:00"   # 早上8点


### PR DESCRIPTION
1.解决return_string_without_jail_break中的模型未就绪导致的“模型未找到”错误

2.新增主动对话功能，通过用户最近不活跃时长计算随机触发。根据角色卡和长期记忆的summary和部分历史上下文当作promt，生成问候语主动发送消息（仅私聊）。

3.重写初始化 Generator 的方法
